### PR TITLE
Expose pre-commit hook for package.json linting

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,13 +18,14 @@
   name: eslint
   language: node
   entry: eslint --fix --cache --ext '.ts,.js' --no-ignore
+
   types:
       - file
   files: \.(js|ts)$
   additional_dependencies:
-      - '@typescript-eslint/eslint-plugin@6.7.0' # sync:yarn.lock
-      - '@typescript-eslint/parser@6.7.0' # sync:yarn.lock
-      - 'eslint@8.49.0' # sync:yarn.lock
+      - '@typescript-eslint/eslint-plugin@6.7.5' # sync:yarn.lock
+      - '@typescript-eslint/parser@6.7.3' # sync:yarn.lock
+      - 'eslint@8.51.0' # sync:yarn.lock
       - 'eslint-config-prettier@9.0.0' # sync:yarn.lock
       - 'eslint-plugin-import@2.28.1' # sync:yarn.lock
       - 'eslint-plugin-es@4.1.0' # sync:yarn.lock
@@ -32,5 +33,27 @@
       - 'eslint-plugin-prettier@5.0.0' # sync:yarn.lock
       - 'eslint-plugin-simple-import-sort@10.0.0' # sync:yarn.lock
       - 'import-modules@3.2.0' # sync:yarn.lock
+      - 'prettier@3.3.3' # sync:yarn.lock
+      - 'typescript@5.2.2' # sync:yarn.lock
+
+- id: eslint-package-json
+  name: eslint_package_json
+  language: node
+  entry: eslint --cache --fix --no-ignore
+
+  types:
+      - file
+  files: package.json
+  additional_dependencies:
+      - '@typescript-eslint/eslint-plugin@6.7.5' # sync:yarn.lock
+      - '@typescript-eslint/parser@6.7.3' # sync:yarn.lock
+      - 'eslint@8.51.0' # sync:yarn.lock
+      - 'eslint-config-prettier@9.0.0' # sync:yarn.lock
+      - 'eslint-plugin-import@2.28.1' # sync:yarn.lock
+      - 'eslint-plugin-es@4.1.0' # sync:yarn.lock
+      - 'eslint-plugin-package-json@0.33.2' # sync:yarn.lock
+      - 'eslint-plugin-prettier@5.0.0' # sync:yarn.lock
+      - 'import-modules@3.2.0' # sync:yarn.lock
+      - 'jsonc-eslint-parser@2.4.0' # sync:yarn.lock
       - 'prettier@3.3.3' # sync:yarn.lock
       - 'typescript@5.2.2' # sync:yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gamechanger/eslint-plugin",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "description": "GC Lint Rules for TS Projects",
     "homepage": "https://github.com/gamechanger/lint",
     "bugs": {


### PR DESCRIPTION
Though I added support for linting package.json in the previous PR, I didn't expose a hook for pre-commit to access it. The existing hook is filtered to .ts|.js. I felt it would be fine to create a new hook as to not increase complexity