### PR TITLE
Lint rule: pin package.json versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,19 @@ module.exports = {
                         '@typescript-eslint/no-var-requires': 'off',
                     },
                 },
+                {
+                    extends: ['plugin:package-json/legacy-recommended'],
+                    files: ['package.json'],
+                    parser: 'jsonc-eslint-parser',
+                    rules: {
+                        'package-json/restrict-dependency-ranges': [
+                            'error',
+                            {
+                                rangeType: 'pin',
+                            },
+                        ],
+                    },
+                },
             ],
         },
     },


### PR DESCRIPTION
Third time is a charm? Enabling the version pinning of package.jsons here.