### PR TITLE
Add missing additional_dependencies to hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -30,9 +30,11 @@
       - 'eslint-plugin-import@2.28.1' # sync:yarn.lock
       - 'eslint-plugin-es@4.1.0' # sync:yarn.lock
       - 'eslint-plugin-no-only-tests@3.1.0' # sync:yarn.lock
+      - 'eslint-plugin-package-json@0.33.2' # sync:yarn.lock
       - 'eslint-plugin-prettier@5.0.0' # sync:yarn.lock
       - 'eslint-plugin-simple-import-sort@10.0.0' # sync:yarn.lock
       - 'import-modules@3.2.0' # sync:yarn.lock
+      - 'jsonc-eslint-parser@2.4.0' # sync:yarn.lock
       - 'prettier@3.3.3' # sync:yarn.lock
       - 'typescript@5.2.2' # sync:yarn.lock
 
@@ -51,8 +53,10 @@
       - 'eslint-config-prettier@9.0.0' # sync:yarn.lock
       - 'eslint-plugin-import@2.28.1' # sync:yarn.lock
       - 'eslint-plugin-es@4.1.0' # sync:yarn.lock
+      - 'eslint-plugin-no-only-tests@3.1.0' # sync:yarn.lock
       - 'eslint-plugin-package-json@0.33.2' # sync:yarn.lock
       - 'eslint-plugin-prettier@5.0.0' # sync:yarn.lock
+      - 'eslint-plugin-simple-import-sort@10.0.0' # sync:yarn.lock
       - 'import-modules@3.2.0' # sync:yarn.lock
       - 'jsonc-eslint-parser@2.4.0' # sync:yarn.lock
       - 'prettier@3.3.3' # sync:yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gamechanger/eslint-plugin",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "description": "GC Lint Rules for TS Projects",
     "homepage": "https://github.com/gamechanger/lint",
     "bugs": {


### PR DESCRIPTION
I tailored the list of `additional_dependencies` in the .pre-commit-hooks.yaml but I think that was a mistake. The .estslintrc.js is being loaded when either eslint or estlint-package-json hooks are used. And I think because of that, both of these need to list the full set of packages used in the rc file. [The eden build pulling in v18 of this library is failing in the pre-commit](https://github.com/gamechanger/eden/actions/runs/15544139485/job/43762077652?pr=18538). The **eslint** hook complains it can't find `eslint-plugin-package-json` and the **eslint-package-json** hook complains it can't find `eslint-plugin-simple-import-sort`. Those were missing from the respective `additional_dependencies` section of the hooks file.

[sc-429617]