### PR TITLE
chore: update stale-branches action to v8

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Stale Branches
-      uses: gamechanger/stale-branches@f09051a0164b595cfa02a4fadbc27ee47499ee10 #v3.0.0
+      uses: gamechanger/stale-branches@v8
       with:
         repo-token: '${{ secrets.GITHUB_TOKEN }}'
         days-before-stale: 45


### PR DESCRIPTION
Moving GitHub actions off of Node 20 which is deprecated in June.

[sc-486993](https://app.shortcut.com/gamechangermedia/story/486993/github-actions-node-20-deprecation-6-2-deadline)