### PR TITLE
Rollback eslint-plugin-package-json min age issue

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -30,7 +30,7 @@
       - 'eslint-config-prettier@10.1.8' # sync:yarn.lock
       - 'eslint-plugin-es@4.1.0' # sync:yarn.lock
       - 'eslint-plugin-no-only-tests@3.4.0' # sync:yarn.lock
-      - 'eslint-plugin-package-json@1.6.0' # sync:yarn.lock
+      - 'eslint-plugin-package-json@1.5.0' # sync:yarn.lock
       - 'eslint-plugin-prettier@5.5.6' # sync:yarn.lock
       - 'eslint-plugin-simple-import-sort@13.0.0' # sync:yarn.lock
       - 'import-modules@3.2.0' # sync:yarn.lock
@@ -55,7 +55,7 @@
       - 'eslint-config-prettier@10.1.8' # sync:yarn.lock
       - 'eslint-plugin-es@4.1.0' # sync:yarn.lock
       - 'eslint-plugin-no-only-tests@3.4.0' # sync:yarn.lock
-      - 'eslint-plugin-package-json@1.6.0' # sync:yarn.lock
+      - 'eslint-plugin-package-json@1.5.0' # sync:yarn.lock
       - 'eslint-plugin-prettier@5.5.6' # sync:yarn.lock
       - 'eslint-plugin-simple-import-sort@13.0.0' # sync:yarn.lock
       - 'import-modules@3.2.0' # sync:yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gamechanger/eslint-plugin",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "GC Lint Rules for TS Projects",
     "homepage": "https://github.com/gamechanger/lint",
     "bugs": {
@@ -24,7 +24,7 @@
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-es": "4.1.0",
         "eslint-plugin-no-only-tests": "3.4.0",
-        "eslint-plugin-package-json": "1.6.0",
+        "eslint-plugin-package-json": "1.5.0",
         "eslint-plugin-prettier": "5.5.6",
         "eslint-plugin-simple-import-sort": "13.0.0",
         "import-modules": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,11 +313,10 @@ eslint-config-prettier@10.1.8:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz#15734ce4af8c2778cc32f0b01b37b0b5cd1ecb97"
   integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==
 
-eslint-fix-utils@~0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/eslint-fix-utils/-/eslint-fix-utils-0.4.3.tgz#533c23295776c4e08a18ad7c7020f5779274a6bb"
-  integrity sha512-EKzNhsNavV5DdkHVltHBM9TqfsonCmiUhOm1Ra97zo03M9IAx3wtM1eC27eWGMj/D3LrALmHHNe1QlQH1P7Nxw==
-
+eslint-fix-utils@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-fix-utils/-/eslint-fix-utils-0.4.2.tgz#d7c034480fe1a537ff84f340a1970c977daade71"
+  integrity sha512-n7ZTcwwkP5scedlhvWMcqxED+O1NzXcj5Rxn/0kJQMP88k02vRcBfQ1qsk/JHb6Aw8bajFoetFCCBiNIcNCsvA==
 eslint-json-compat-utils@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.3.tgz#f6ef27e80c750b56cbedb4de67a10b1d47f0a8a7"
@@ -338,16 +337,16 @@ eslint-plugin-no-only-tests@3.4.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.4.0.tgz#a457d2c559bda3301ce5a75147b8ba447186e88a"
   integrity sha512-4S3/9Nb7A2tiMcpzEQE9bQSlpeOz6WJkgryBuou/SA8W2x2c8Zf4j0NvTKBjv6qNhF9T79tmkecm/0CHqV0UGg==
 
-eslint-plugin-package-json@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-package-json/-/eslint-plugin-package-json-1.6.0.tgz#46607c82204462635147f91f1f10b069485e5a6e"
-  integrity sha512-pROaDdg6qRV7RF6qebqoXIuPBagHI1jNklZBKP0IPikfL2hW25JZnBp4Q0tmdNJZx2LIh3rgdmcqqz4CIkSuCg==
+eslint-plugin-package-json@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-package-json/-/eslint-plugin-package-json-1.5.0.tgz#9e5889703b3815147dcafd5c65a31acac42bebed"
+  integrity sha512-KQkAdn+7I4vn1W4Va+V8M94RhcgZBvgrxMglDqgEhJgQDRUJ9RdtrEiHoe/84oVTIlp0jiPttLYwkExdvHYhZQ==
   dependencies:
     "@altano/repository-tools" "^2.0.1"
     change-case "^5.4.4"
     detect-indent "^7.0.2"
     detect-newline "^4.0.1"
-    eslint-fix-utils "~0.4.3"
+    eslint-fix-utils "~0.4.1"
     eslint-json-compat-utils "^0.2.3"
     jsonc-eslint-parser "^3.1.0"
     package-json-validator "^1.5.0"


### PR DESCRIPTION
Fix for #216 that included packages that were not 7 days matured. This broke eden being able to use it.  And we want to adopt TS7 NOW. This rollbacks are no big deal as they reflect the versions in use before #216.