### PR TITLE
Lint rule audit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -23,6 +23,7 @@
       - file
   files: \.(js|ts)$
   additional_dependencies:
+      - '@stylistic/eslint-plugin@5.10.0' # sync:yarn.lock
       - '@typescript-eslint/eslint-plugin@8.63.0' # sync:yarn.lock
       - '@typescript-eslint/parser@8.63.0' # sync:yarn.lock
       - 'eslint@10.6.0' # sync:yarn.lock
@@ -46,6 +47,7 @@
       - file
   files: package.json
   additional_dependencies:
+      - '@stylistic/eslint-plugin@5.10.0' # sync:yarn.lock
       - '@typescript-eslint/eslint-plugin@8.63.0' # sync:yarn.lock
       - '@typescript-eslint/parser@8.63.0' # sync:yarn.lock
       - 'eslint@10.6.0' # sync:yarn.lock

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,35 +17,11 @@
 - id: eslint
   name: eslint
   language: node
-  entry: eslint --fix --cache --ext '.ts,.js' --no-ignore
+  entry: eslint --fix --cache --no-ignore
 
   types:
       - file
-  files: \.(js|ts)$
-  additional_dependencies:
-      - '@stylistic/eslint-plugin@5.10.0' # sync:yarn.lock
-      - '@typescript-eslint/eslint-plugin@8.63.0' # sync:yarn.lock
-      - '@typescript-eslint/parser@8.63.0' # sync:yarn.lock
-      - 'eslint@10.6.0' # sync:yarn.lock
-      - 'eslint-config-prettier@10.1.8' # sync:yarn.lock
-      - 'eslint-plugin-no-only-tests@3.4.0' # sync:yarn.lock
-      - 'eslint-plugin-package-json@1.5.0' # sync:yarn.lock
-      - 'eslint-plugin-prettier@5.5.6' # sync:yarn.lock
-      - 'eslint-plugin-simple-import-sort@13.0.0' # sync:yarn.lock
-      - 'import-modules@3.2.0' # sync:yarn.lock
-      - 'jsonc-eslint-parser@3.1.0' # sync:yarn.lock
-      - 'typescript-eslint@8.63.0' # sync:yarn.lock
-      - 'prettier@3.9.4' # sync:yarn.lock
-      - 'typescript@6.0.3' # sync:yarn.lock
-
-- id: eslint-package-json
-  name: eslint_package_json
-  language: node
-  entry: eslint --cache --fix --no-ignore
-
-  types:
-      - file
-  files: package.json
+  files: (\.(js|ts)$|(^|/)package\.json$)
   additional_dependencies:
       - '@stylistic/eslint-plugin@5.10.0' # sync:yarn.lock
       - '@typescript-eslint/eslint-plugin@8.63.0' # sync:yarn.lock

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -23,12 +23,10 @@
       - file
   files: \.(js|ts)$
   additional_dependencies:
-      - '@eslint/compat@2.1.0' # sync:yarn.lock
       - '@typescript-eslint/eslint-plugin@8.63.0' # sync:yarn.lock
       - '@typescript-eslint/parser@8.63.0' # sync:yarn.lock
       - 'eslint@10.6.0' # sync:yarn.lock
       - 'eslint-config-prettier@10.1.8' # sync:yarn.lock
-      - 'eslint-plugin-es@4.1.0' # sync:yarn.lock
       - 'eslint-plugin-no-only-tests@3.4.0' # sync:yarn.lock
       - 'eslint-plugin-package-json@1.5.0' # sync:yarn.lock
       - 'eslint-plugin-prettier@5.5.6' # sync:yarn.lock
@@ -48,12 +46,10 @@
       - file
   files: package.json
   additional_dependencies:
-      - '@eslint/compat@2.1.0' # sync:yarn.lock
       - '@typescript-eslint/eslint-plugin@8.63.0' # sync:yarn.lock
       - '@typescript-eslint/parser@8.63.0' # sync:yarn.lock
       - 'eslint@10.6.0' # sync:yarn.lock
       - 'eslint-config-prettier@10.1.8' # sync:yarn.lock
-      - 'eslint-plugin-es@4.1.0' # sync:yarn.lock
       - 'eslint-plugin-no-only-tests@3.4.0' # sync:yarn.lock
       - 'eslint-plugin-package-json@1.5.0' # sync:yarn.lock
       - 'eslint-plugin-prettier@5.5.6' # sync:yarn.lock

--- a/README.md
+++ b/README.md
@@ -22,16 +22,13 @@
 1. From a terminal in the Eden folder run this command
 
 ```
-pre-commit try-repo ../lint some_hook
+pre-commit try-repo ../lint eslint
 ```
-
-replacing `some_hook` with either `eslint` to lint the TS and JS or `eslint-package-json` to lint the package files.
 
 ---
 
-### Important Notes
+### Package Bumps
 
-#### additional_dependencies for eslint based hooks
-It is unfortunate but necessary that the `additional_dependencies` section in the .pre-commit-hooks.yaml, for any hook that uses eslint, include ALL of the dependencies used by every eslint hook. This is because the index.js file is loaded no matter which eslint driven hook is run, and it will fail to load due to missing depenedencies. Remember, pre-commit handles dependencies differently so even if they are in the node_modules folder, that isn't good enough.
+After updating dependencies, stage package.json and yarn.lock, then run `pre-commit`. This will update the .pre-commit-hooks.yaml `additional_dependencies` section. These must be kept in sync!
 
 ---

--- a/index.js
+++ b/index.js
@@ -4,22 +4,21 @@ const path = require('path');
 const importModules = require('import-modules');
 
 const noOnlyTest = require('eslint-plugin-no-only-tests');
-const { fixupPluginRules } = require('@eslint/compat');
 
 module.exports = defineConfig([
     require('typescript-eslint').configs.recommended,
     {
         plugins: {
-            es: fixupPluginRules(require('eslint-plugin-es')),
             'simple-import-sort': require('eslint-plugin-simple-import-sort'),
             'no-only-tests': noOnlyTest,
             prettier: require('eslint-plugin-prettier'),
             '@gamechanger': {
                 rules: importModules(path.resolve(__dirname, 'rules'), { camelize: false }),
-            }
+            },
         },
         rules: {
-            // default
+            // core ESLint — typescript-eslint/recommended does NOT pull in eslint:recommended,
+            // so each of these is doing real work.
             'array-element-newline': ['error', 'consistent'],
             'arrow-body-style': ['error', 'as-needed'],
             'object-shorthand': ['error', 'always'],
@@ -29,33 +28,8 @@ module.exports = defineConfig([
             // prettier
             'prettier/prettier': 'error',
 
-            // @typescript-eslint
-            '@typescript-eslint/camelcase': 'off',
-            '@typescript-eslint/class-name-casing': 'off',
-            '@typescript-eslint/no-use-before-define': 'off',
-            '@typescript-eslint/no-inferrable-types': 'off',
-            '@typescript-eslint/implicit-arrow-linebreak': 'off',
-            '@typescript-eslint/no-unused-vars': [
-                'off',
-                {
-                    argsIgnorePattern: '^[_a]',
-                    varsIgnorePattern: '^[_a]',
-                },
-            ],
-
-            // es
-            'es/no-object-assign': 'error',
-
-            // simple-import-sort
-            // imports are enforced via simple import sort plugin
-            // so disable default sort-imports
+            // simple-import-sort (replaces core sort-imports for TS)
             'simple-import-sort/imports': 'error',
-            'sort-imports': 'off',
-
-            // import plugin rules
-            'import/no-unresolved': 'off',
-            'import/namespace': 'off',
-            'import/export': 'off',
 
             // no-only-tests
             'no-only-tests/no-only-tests': [
@@ -67,21 +41,23 @@ module.exports = defineConfig([
                     ),
                 },
             ],
-            // @typescript-eslint
-            '@typescript-eslint/no-empty-interface': 'off',
-            '@typescript-eslint/no-empty-function': 'off',
+
+            // @typescript-eslint — overrides of rules that `recommended` turns ON
             '@typescript-eslint/no-explicit-any': 'off',
-            '@typescript-eslint/explicit-function-return-type': 'off',
-            '@typescript-eslint/no-non-null-assertion': 'off',
-            '@typescript-eslint/explicit-module-boundary-types': 'off',
-            '@typescript-eslint/no-unused-expressions': 'off', // Reports test assertions as unused
-            '@typescript-eslint/no-empty-object-type': 'off', // Reports our common empty interface usage as an error
+            '@typescript-eslint/no-empty-object-type': 'off', // our common empty-interface pattern
             '@typescript-eslint/no-require-imports': 'off',
-            '@typescript-eslint/no-var-requires': 'error',
+            '@typescript-eslint/no-unused-vars': 'off',
+            '@typescript-eslint/no-unused-expressions': 'off', // recommended=error; would flag chai assertions
+
+            // @typescript-eslint — pre-staged opt-outs for the planned `strict`/`stylistic` adoption.
+            // Inert under `recommended` alone; kept so that migration doesn't surface these as new errors.
+            '@typescript-eslint/no-non-null-assertion': 'off', // strict
+            '@typescript-eslint/no-inferrable-types': 'off', // stylistic
+            '@typescript-eslint/no-empty-function': 'off', // stylistic
 
             // @gamechanger
             '@gamechanger/capitalize-star-imports': 'error',
-        }
+        },
     },
     {
         files: ['**/*.js'],
@@ -89,7 +65,6 @@ module.exports = defineConfig([
             // this plugin cant sort require() hence fallback to default sort
             'simple-import-sort/imports': 'off',
             'sort-imports': ['error'],
-            '@typescript-eslint/no-var-requires': 'off',
             'prettier/prettier': 'off',
         },
     },

--- a/index.js
+++ b/index.js
@@ -12,18 +12,20 @@ module.exports = defineConfig([
         plugins: {
             'simple-import-sort': require('eslint-plugin-simple-import-sort'),
             'no-only-tests': noOnlyTest,
+            '@stylistic': require('@stylistic/eslint-plugin'),
             '@gamechanger': {
                 rules: importModules(path.resolve(__dirname, 'rules'), { camelize: false }),
             },
         },
         rules: {
             // core ESLint — typescript-eslint/recommended does NOT pull in eslint:recommended,
-            // so each of these is doing real work.
-            'array-element-newline': ['error', 'consistent'],
-            'arrow-body-style': ['error', 'as-needed'],
+            // so these are doing real work.
             'object-shorthand': ['error', 'always'],
-            'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
             'no-debugger': 'error',
+
+            // @stylistic — layout rules Prettier does not cover. New home for the deprecated core
+            // `lines-between-class-members`; config-prettier leaves this one on, so it stays active.
+            '@stylistic/lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
 
             // simple-import-sort (replaces core sort-imports for TS)
             'simple-import-sort/imports': 'error',

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = defineConfig([
         },
     },
     {
-        files: ['package.json'],
+        files: ['**/package.json'],
         languageOptions: {
             parser: require('jsonc-eslint-parser'),
         },

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const importModules = require('import-modules');
 
 const noOnlyTest = require('eslint-plugin-no-only-tests');
+const prettierRecommended = require('eslint-plugin-prettier/recommended');
 
 module.exports = defineConfig([
     require('typescript-eslint').configs.recommended,
@@ -11,7 +12,6 @@ module.exports = defineConfig([
         plugins: {
             'simple-import-sort': require('eslint-plugin-simple-import-sort'),
             'no-only-tests': noOnlyTest,
-            prettier: require('eslint-plugin-prettier'),
             '@gamechanger': {
                 rules: importModules(path.resolve(__dirname, 'rules'), { camelize: false }),
             },
@@ -24,9 +24,6 @@ module.exports = defineConfig([
             'object-shorthand': ['error', 'always'],
             'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
             'no-debugger': 'error',
-
-            // prettier
-            'prettier/prettier': 'error',
 
             // simple-import-sort (replaces core sort-imports for TS)
             'simple-import-sort/imports': 'error',
@@ -59,6 +56,11 @@ module.exports = defineConfig([
             '@gamechanger/capitalize-star-imports': 'error',
         },
     },
+    // Registers the `prettier` plugin, sets `prettier/prettier: error`, and (via eslint-config-prettier)
+    // turns off core/stylistic rules that conflict with Prettier. Placed AFTER the main block so those
+    // opt-outs win, and BEFORE the `.js` block so `.js` keeps `prettier/prettier: off`.
+    // NOTE: this also turns OFF `arrow-body-style` and `prefer-arrow-callback` (known prettier autofix conflicts).
+    prettierRecommended,
     {
         files: ['**/*.js'],
         rules: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gamechanger/eslint-plugin",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "description": "GC Lint Rules for TS Projects",
     "homepage": "https://github.com/gamechanger/lint",
     "bugs": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "author": "GameChanger",
     "main": "./index.js",
     "dependencies": {
+        "@stylistic/eslint-plugin": "5.10.0",
         "@typescript-eslint/eslint-plugin": "8.63.0",
         "@typescript-eslint/parser": "8.63.0",
         "eslint": "10.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gamechanger/eslint-plugin",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "description": "GC Lint Rules for TS Projects",
     "homepage": "https://github.com/gamechanger/lint",
     "bugs": {
@@ -17,12 +17,10 @@
     "author": "GameChanger",
     "main": "./index.js",
     "dependencies": {
-        "@eslint/compat": "2.1.0",
         "@typescript-eslint/eslint-plugin": "8.63.0",
         "@typescript-eslint/parser": "8.63.0",
         "eslint": "10.6.0",
         "eslint-config-prettier": "10.1.8",
-        "eslint-plugin-es": "4.1.0",
         "eslint-plugin-no-only-tests": "3.4.0",
         "eslint-plugin-package-json": "1.5.0",
         "eslint-plugin-prettier": "5.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,13 +26,6 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
   integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
 
-"@eslint/compat@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eslint/compat/-/compat-2.1.0.tgz#8c66110f95cf0fdd864b76ae4d534042dea7bb7f"
-  integrity sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==
-  dependencies:
-    "@eslint/core" "^1.2.1"
-
 "@eslint/config-array@^0.23.5":
   version "0.23.5"
   resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.23.5.tgz#56e86d243049195d8acc0c06a1b3dfdc3fa3de95"
@@ -317,20 +310,13 @@ eslint-fix-utils@~0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/eslint-fix-utils/-/eslint-fix-utils-0.4.2.tgz#d7c034480fe1a537ff84f340a1970c977daade71"
   integrity sha512-n7ZTcwwkP5scedlhvWMcqxED+O1NzXcj5Rxn/0kJQMP88k02vRcBfQ1qsk/JHb6Aw8bajFoetFCCBiNIcNCsvA==
+
 eslint-json-compat-utils@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.3.tgz#f6ef27e80c750b56cbedb4de67a10b1d47f0a8a7"
   integrity sha512-RbBmDFyu7FqnjE8F0ZxPNzx5UaptdeS9Uu50r7A+D7s/+FCX+ybiyViYEgFUaFIFqSWJgZRTpL5d8Kanxxl2lQ==
   dependencies:
     esquery "^1.6.0"
-
-eslint-plugin-es@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz#f0822f0c18a535a97c3e714e89f88586a7641ec9"
-  integrity sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==
-  dependencies:
-    eslint-utils "^2.0.0"
-    regexpp "^3.0.0"
 
 eslint-plugin-no-only-tests@3.4.0:
   version "3.4.0"
@@ -376,18 +362,6 @@ eslint-scope@^9.1.2:
     "@types/estree" "^1.0.8"
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
-
-eslint-utils@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
-  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
-  dependencies:
-    eslint-visitor-keys "^1.1.0"
-
-eslint-visitor-keys@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
-  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^3.4.3:
   version "3.4.3"
@@ -737,11 +711,6 @@ punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
-regexpp@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
-  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
 semver@^7.3.5:
   version "7.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,18 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.3.6.tgz#3569708bd4be4d8870ba32bf1c456dac81600d97"
   integrity sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==
 
+"@stylistic/eslint-plugin@5.10.0":
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz#471bbd9f7a27ceaac4a217e7f5b3890855e5640c"
+  integrity sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/types" "^8.56.0"
+    eslint-visitor-keys "^4.2.1"
+    espree "^10.4.0"
+    estraverse "^5.3.0"
+    picomatch "^4.0.3"
+
 "@types/esrecurse@^4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/esrecurse/-/esrecurse-4.3.1.tgz#6f636af962fbe6191b830bd676ba5986926bccec"
@@ -178,6 +190,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.63.0.tgz#6b32b0a5913520554d81a986acfffba2d32b6963"
   integrity sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==
 
+"@typescript-eslint/types@^8.56.0":
+  version "8.65.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.65.0.tgz#3e86738416a777c8b8925ab46745f48ecf904c9f"
+  integrity sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==
+
 "@typescript-eslint/types@^8.63.0":
   version "8.64.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.64.0.tgz#b41f8ef5dd40616908658b991197a9d486cda60b"
@@ -221,7 +238,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.16.0:
+acorn@^8.15.0, acorn@^8.16.0:
   version "8.17.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.17.0.tgz#1785adb84faf8d8add10369b93826fc2bd08f1fe"
   integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==
@@ -368,6 +385,11 @@ eslint-visitor-keys@^3.4.3:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
+eslint-visitor-keys@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
+  integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
+
 eslint-visitor-keys@^5.0.0, eslint-visitor-keys@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
@@ -409,6 +431,15 @@ eslint@10.6.0:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
+espree@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-10.4.0.tgz#d54f4949d4629005a1fa168d937c3ff1f7e2a837"
+  integrity sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^4.2.1"
+
 espree@^11.2.0:
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-11.2.0.tgz#01d5e47dc332aaba3059008362454a8cc34ccaa5"
@@ -432,7 +463,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -680,7 +711,7 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-picomatch@^4.0.4:
+picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==


### PR DESCRIPTION
## ESLint config modernization + single pre-commit hook (v4.0.0)

### Summary
Modernizes the shared ESLint config for the current toolchain (`typescript-eslint@8.63`, `eslint@10.6`, `prettier@3.9`): removes dead/redundant rules, adopts `eslint-plugin-prettier/recommended`, migrates the last deprecated formatting rule to `@stylistic`, extends `package.json` linting to nested files, and **consolidates the two eslint pre-commit hooks into one**. Net dependency change: −2, +1.

Released as **4.0.0 (major)** because the pre-commit hook consolidation is a breaking change for consumers (see below). Validated end-to-end against eden.

### ⚠️ Breaking changes (why this is a major)
1. **The `eslint-package-json` pre-commit hook is removed.** Its behavior is folded into the single `eslint` hook. Any consumer `.pre-commit-config.yaml` that lists `- id: eslint-package-json` **must delete that line** when bumping `rev`, or pre-commit fails with "hook not found."
2. **Nested `package.json` files are now linted** (previously only the repo-root file matched). Consumers may see new errors in nested `package.json` files that use unpinned dependency ranges (`^`/`~`), and nested `package.json` formatting is now enforced by Prettier. Most surface as auto-fixable `prettier/prettier` nits.

### Changes

**1. Dead & redundant rule cleanup**
- Removed dead references: `@typescript-eslint/camelcase`, `class-name-casing`, `implicit-arrow-linebreak` (gone from the plugin); `import/no-unresolved` / `namespace` / `export` (`eslint-plugin-import` not installed).
- Removed deprecated, superseded rules: `no-empty-interface` (→ `no-empty-object-type`, kept) and `no-var-requires` (→ `no-require-imports`, kept).
- Removed `'off'` lines redundant against `recommended`/`strict`/`stylistic`: `no-use-before-define`, `explicit-function-return-type`, `explicit-module-boundary-types`, plus the inert options object on the (off) `no-unused-vars`.
- Kept all real `recommended` overrides; kept three opt-outs (`no-non-null-assertion`, `no-inferrable-types`, `no-empty-function`) pre-staged for a planned `strict`/`stylistic` adoption.

**2. Adopt `eslint-plugin-prettier/recommended`**
- Replaced the hand-wired `prettier` plugin + `prettier/prettier: 'error'` with the `/recommended` bundle, which also applies `eslint-config-prettier` (turns off core/stylistic rules that conflict with Prettier). `prettier/prettier` remains `error` — Prettier still runs. Ordered after the main block and before the `.js` block so `.js` keeps `prettier/prettier: off`.

**3. Migrate the last deprecated formatting rule to `@stylistic`**
- Dropped `array-element-newline` (config-prettier disables it; Prettier owns array layout).
- Migrated `lines-between-class-members` → `@stylistic/lines-between-class-members` (deprecated in core; config-prettier leaves it on). Added `@stylistic/eslint-plugin@5.10.0`.

**4. Dependency cleanup**
- Removed `eslint-plugin-es` + `es/no-object-assign` (obsolete ES5 rule) and its `@eslint/compat` `fixupPluginRules` shim. Removed both from `package.json`, both pre-commit hooks, and `yarn.lock`.

**5. Condense to a single pre-commit hook**
- Merged `eslint` and `eslint-package-json` into one `eslint` hook. Files pattern is now `(\.(js|ts)$|(^|/)package\.json$)` and flat config routes each file type to the right rules. Dropped the legacy `--ext '.ts,.js'` flag. Eliminates the duplicated `additional_dependencies` list (the README's "keep every dep in every hook in sync" burden is gone) and halves the isolated-env install per run.

**6. Lint nested `package.json` files**
- `files: ['package.json']` → `files: ['**/package.json']`. The bare pattern only matched the repo root; the glob matches every depth.

### Dependency changes
- **Removed:** `@eslint/compat`, `eslint-plugin-es`
- **Added:** `@stylistic/eslint-plugin@5.10.0` (in `dependencies`, so consumers receive it)
- **Version:** `3.0.1` → `4.0.0`

### Behavior changes (rule-level, all intentional)
- `es/no-object-assign` removed → `Object.assign()` no longer flagged (ES5-era rule).
- `no-var-requires` removed → `const x = require(...)` in `.ts` no longer flagged (`no-require-imports` was already `off`).
- `arrow-body-style` no longer enforced (disabled by the prettier plugin's recommended — documented autofix conflict).
- `array-element-newline` no longer enforced (Prettier owns it).
- `lines-between-class-members` enforcement **preserved** via `@stylistic` (gains a sensible `exceptAfterOverload` default).
- Nested `package.json` files now linted.

### Verification
- Ran the config against eden (6007 files) after each step — **0 errors throughout** (104 warnings are eden-specific rules, unrelated). Adopting `eslint-plugin-prettier/recommended` introduced 0 new problems.
- The nested-`package.json` fix surfaced 9 auto-fixable `prettier/prettier` nits (fixed); confirmed `**/package.json` matches root + nested and doesn't break root linting.
- Ran the merged single hook via a real `pre-commit run eslint --all-files` against eden → **Passed**.

### Consumer migration (per repo)
1. Bump `@gamechanger/eslint-plugin` to `4.0.0`.
2. Bump the pre-commit `rev` to `v4.0.0` **and delete the `- id: eslint-package-json` line** from `.pre-commit-config.yaml`.
3. Run the hook once with `--fix` to clear any nested-`package.json` formatting nits; pin any unpinned deps it flags.


[sc-508351]